### PR TITLE
Succinct prime field representation for small `p`

### DIFF
--- a/algebraic-prelude/src/AlgebraicPrelude.hs
+++ b/algebraic-prelude/src/AlgebraicPrelude.hs
@@ -440,8 +440,8 @@ instance (Eq a, P.Integral a) => DecidableUnits (WrapIntegral a) where
 
   recipUnit (WrapIntegral r) =
     if isUnit (WrapIntegral r)
-    then Nothing
-    else Just (WrapIntegral r)
+    then Just (WrapIntegral r)
+    else Nothing
   {-# INLINE recipUnit #-}
 
 instance (Eq a, P.Integral a) => DecidableAssociates (WrapIntegral a) where

--- a/halg-core-test/package.yaml
+++ b/halg-core-test/package.yaml
@@ -58,4 +58,6 @@ tests:
     - QuickCheck
     - arithmoi
     - hspec
+    - integer-gmp
+    - template-haskell
     - inspection-testing

--- a/halg-core-test/package.yaml
+++ b/halg-core-test/package.yaml
@@ -37,3 +37,25 @@ dependencies:
 library:
   source-dirs: src
   ghc-options:  -Wall -Wno-orphans
+
+
+tests:
+  halg-core-specs:
+    build-tools:
+    - hspec-discover
+    ghc-options:
+    - -Wall
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+    - -O2
+    main:                Spec.hs
+    source-dirs:         test
+    dependencies:
+    - halg-core
+    - halg-core-test
+    - singletons
+    - QuickCheck
+    - arithmoi
+    - hspec
+    - inspection-testing

--- a/halg-core-test/src/Algebra/Field/Prime/Test.hs
+++ b/halg-core-test/src/Algebra/Field/Prime/Test.hs
@@ -4,14 +4,13 @@
 module Algebra.Field.Prime.Test where
 import Algebra.Field.Finite.Test
 
-import Algebra.Field.Prime    (F)
-import Data.Reflection        (Reifies)
-import Prelude                (Integer, Maybe (..), Monad)
+import Algebra.Field.Prime    (F, IsPrimeChar)
+import Prelude                (Maybe (..), Monad)
 import Test.QuickCheck        (Arbitrary (..))
 import Test.SmallCheck.Series (Serial (..))
 
-instance Reifies p Integer => Arbitrary (F p) where
+instance IsPrimeChar p => Arbitrary (F p) where
   arbitrary = arbitraryFiniteField (Nothing :: Maybe (F p))
 
-instance (Monad m, Reifies p Integer) => Serial m (F p) where
+instance (Monad m, IsPrimeChar p) => Serial m (F p) where
   series = seriesFiniteField (Nothing :: Maybe (F p))

--- a/halg-core-test/src/Algebra/Field/Prime/Test.hs
+++ b/halg-core-test/src/Algebra/Field/Prime/Test.hs
@@ -4,13 +4,16 @@
 module Algebra.Field.Prime.Test where
 import Algebra.Field.Finite.Test
 
-import Algebra.Field.Prime    (F, IsPrimeChar)
-import Prelude                (Maybe (..), Monad)
-import Test.QuickCheck        (Arbitrary (..))
+import Algebra.Field.Prime    (F, IsPrimeChar, modNat)
+import Data.Proxy
+import Data.Reflection
+import Prelude                (Maybe (..), Monad, fromIntegral, (-), (<$>))
+import Test.QuickCheck        (Arbitrary (..), resize)
 import Test.SmallCheck.Series (Serial (..))
 
 instance IsPrimeChar p => Arbitrary (F p) where
-  arbitrary = arbitraryFiniteField (Nothing :: Maybe (F p))
+  arbitrary = modNat <$>
+    resize (fromIntegral (reflect (Proxy :: Proxy p)) - 1) arbitrary
 
 instance (Monad m, IsPrimeChar p) => Serial m (F p) where
   series = seriesFiniteField (Nothing :: Maybe (F p))

--- a/halg-core-test/test/Algebra/Field/PrimeSpec.hs
+++ b/halg-core-test/test/Algebra/Field/PrimeSpec.hs
@@ -1,0 +1,105 @@
+{-# LANGUAGE DataKinds, DerivingStrategies, GADTs                          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving, KindSignatures, NoImplicitPrelude #-}
+{-# LANGUAGE PolyKinds, RankNTypes, ScopedTypeVariables, TemplateHaskell   #-}
+{-# LANGUAGE TypeApplications                                              #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -dsuppress-idinfo -dsuppress-coercions
+      -dsuppress-type-applications
+      -dsuppress-module-prefixes -dsuppress-type-signatures
+      -dsuppress-uniques
+  #-}
+module Algebra.Field.PrimeSpec where
+import           Algebra.Field.Finite.Test ()
+import           Algebra.Field.Prime
+import           Algebra.Field.Prime.Test  ()
+import           AlgebraicPrelude
+import qualified AlgebraicPrelude          as NA
+import           Data.Proxy                (Proxy (..))
+import           Data.Singletons.Prelude
+import           GHC.TypeLits              (Nat)
+import           Math.NumberTheory.Primes
+import qualified Prelude                   as P
+import           Test.Hspec
+import           Test.Hspec.QuickCheck
+import           Test.Inspection           hiding (Property, property, (===))
+import qualified Test.Inspection           as IT
+import           Test.QuickCheck           hiding (elements)
+import qualified Test.QuickCheck           as QC
+import           Unsafe.Coerce             (unsafeCoerce)
+
+bigEnoughPrime :: Prime Integer
+bigEnoughPrime = precPrime $ floor @Double
+  $ sqrt $ fromIntegral $ maxBound @Int
+
+n102F59 :: F 59
+n102F59 = 102
+
+n102F59Manual :: F 59
+n102F59Manual = unsafeCoerce (102 `mod` 59 :: Int)
+
+f59AddPrelude :: F 59 -> F 59 -> F 59
+f59AddPrelude = (P.+)
+
+f59AddAlgebra :: F 59 -> F 59 -> F 59
+f59AddAlgebra = (NA.+)
+
+f59AddManual :: F 59 -> F 59 -> F 59
+f59AddManual = unsafeCoerce $ \(l :: Int) (r :: Int) ->
+  (l + r) `mod` 59
+
+checkInspection
+  :: IT.Result -> Expectation
+checkInspection IT.Success{} = pure ()
+checkInspection (IT.Failure msg) =
+  fail msg
+
+spec :: Spec
+spec = do
+  describe "F p" $ do
+    prop "is a field (for small primes)" $ \(SmallPrime p) ->
+          tabulate "p" [show p] $
+          reifyPrimeField p $ property . isField
+    prop "is a field (for big primes)" $ \(BigPrime p) ->
+      tabulate "p" [show p] $
+      reifyPrimeField p $ property . isField
+    describe "optimisation for small primes (F 59)" $ do
+      it "literal doesn't contain type-natural comparison"
+        $ checkInspection $(inspectTest $ 'n102F59 `doesNotUse` 'SLT)
+      describe "(Prelude.+)" $ do
+        it "doesn't contain type-natural comparison"
+          $ checkInspection $(inspectTest $ 'f59AddPrelude `doesNotUse` 'SLT)
+        it "has the same core as \a b -> (a + b) `mod` 59"
+          $ checkInspection $(inspectTest $ 'f59AddPrelude IT.=== 'f59AddManual)
+      describe "(NA.+)" $ do
+        it "doesn't contain type-natural comparison"
+          $ checkInspection $(inspectTest $ 'f59AddAlgebra `doesNotUse` 'SLT)
+        it "has the same core as \a b -> (a + b) `mod` 59"
+          $ checkInspection $(inspectTest $ 'f59AddAlgebra IT.=== 'f59AddManual)
+
+newtype SmallPrime = SmallPrime { runSmallPrime :: Integer }
+  deriving newtype (Show)
+
+instance Arbitrary SmallPrime where
+  arbitrary = SmallPrime . unPrime
+    <$> QC.elements (take 1000 primes)
+
+newtype BigPrime = BigPrime { runBigPrime :: Integer }
+  deriving newtype (Show)
+
+instance Arbitrary BigPrime where
+  arbitrary = BigPrime . unPrime
+    <$> QC.elements (take 1000 [bigEnoughPrime ..])
+
+isField :: IsPrimeChar (p :: Nat) => Proxy (F p) -> F p -> F p -> F p -> Property
+isField _ e f g =
+  1 * e === e .&&. e * 1 === e .&&. e + 0 === e
+  .&&. (0 + e === e) .&&. (e - e === 0)
+  .&&. (e /= 0 ==> e * recip e === 1 .&&. recip e * e === 1)
+  .&&. e + f === f + e .&&. e * f === f * e
+  .&&. e * (f * g) === (e * f) * g
+  .&&. e + (f + g) === (e + f) + g
+  .&&. e * (f + g) === e*f + e*g
+
+instance Testable IT.Result where
+  property IT.Success{} = property True
+  property (IT.Failure msg) = error $ "Inspection failure: " ++ msg

--- a/halg-core-test/test/Algebra/Field/PrimeSpec.hs
+++ b/halg-core-test/test/Algebra/Field/PrimeSpec.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE DataKinds, DerivingStrategies, GADTs                          #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving, KindSignatures, NoImplicitPrelude #-}
-{-# LANGUAGE PolyKinds, RankNTypes, ScopedTypeVariables, TemplateHaskell   #-}
-{-# LANGUAGE TypeApplications                                              #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving, KindSignatures, MagicHash         #-}
+{-# LANGUAGE NoImplicitPrelude, PolyKinds, RankNTypes, ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell, TypeApplications                             #-}
+{-# OPTIONS_GHC -Wno-orphans -O2 #-}
 {-# OPTIONS_GHC -dsuppress-idinfo -dsuppress-coercions
       -dsuppress-type-applications
       -dsuppress-module-prefixes -dsuppress-type-signatures
@@ -16,7 +16,10 @@ import           AlgebraicPrelude
 import qualified AlgebraicPrelude          as NA
 import           Data.Proxy                (Proxy (..))
 import           Data.Singletons.Prelude
-import           GHC.TypeLits              (Nat)
+import           GHC.Base                  (modInt#)
+import           GHC.Integer
+import           GHC.TypeLits              (Nat, natVal)
+import           Language.Haskell.TH
 import           Math.NumberTheory.Primes
 import qualified Prelude                   as P
 import           Test.Hspec
@@ -31,6 +34,10 @@ bigEnoughPrime :: Prime Integer
 bigEnoughPrime = precPrime $ floor @Double
   $ sqrt $ fromIntegral $ maxBound @Int
 
+type LargeP = $(litT $ numTyLit $ unPrime
+  $ nextPrime $ floor @Double
+  $ sqrt $ fromIntegral $ maxBound @Int)
+
 n102F59 :: F 59
 n102F59 = 102
 
@@ -43,9 +50,19 @@ f59AddPrelude = (P.+)
 f59AddAlgebra :: F 59 -> F 59 -> F 59
 f59AddAlgebra = (NA.+)
 
-f59AddManual :: F 59 -> F 59 -> F 59
-f59AddManual = unsafeCoerce $ \(l :: Int) (r :: Int) ->
+f59AddManual :: Int -> Int -> Int
+f59AddManual = \l r ->
   (l + r) `mod` 59
+
+fLargeAddPrelude :: F LargeP -> F LargeP -> F LargeP
+fLargeAddPrelude = (P.+)
+
+fLargeAddAlgebra :: F LargeP -> F LargeP -> F LargeP
+fLargeAddAlgebra = (NA.+)
+
+fLargeAddManual :: Integer -> Integer -> Integer
+fLargeAddManual = \ l r ->
+  (l + r) `mod` natVal @LargeP Proxy
 
 checkInspection
   :: IT.Result -> Expectation
@@ -53,42 +70,100 @@ checkInspection IT.Success{} = pure ()
 checkInspection (IT.Failure msg) =
   fail msg
 
+n43 :: Int
+n43 = 43
+
+litLarge :: F LargeP
+litLarge = $(
+  let p = unPrime $ nextPrime $ floor @Double
+        $ sqrt $ fromIntegral $ maxBound @Int
+  in litE $ integerL $ p*3 `div` 2
+  )
+
+litLargeAnswer :: Integer
+litLargeAnswer = $(
+  let p = unPrime $ nextPrime $ floor @Double
+        $ sqrt $ fromIntegral $ maxBound @Int
+  in litE $ integerL $ (p*3 `div` 2) `mod` p
+  )
+
 spec :: Spec
 spec = do
   describe "F p" $ do
     prop "is a field (for small primes)" $ \(SmallPrime p) ->
           tabulate "p" [show p] $
           reifyPrimeField p $ property . isField
+    prop "is a field (for small, but medium primes)" $ \(MediumPrime p) ->
+          tabulate "p" [show p] $
+          reifyPrimeField p $ property . isField
     prop "is a field (for big primes)" $ \(BigPrime p) ->
       tabulate "p" [show p] $
       reifyPrimeField p $ property . isField
     describe "optimisation for small primes (F 59)" $ do
-      it "literal doesn't contain type-natural comparison"
-        $ checkInspection $(inspectTest $ 'n102F59 `doesNotUse` 'SLT)
+      describe "literal" $ do
+        it "doesn't contain type-classes"
+          $ checkInspection $(inspectTest $ hasNoTypeClasses 'n102F59)
+        it "is an immediate value modulo casting"
+          $ checkInspection $(inspectTest $ 'n102F59 ==- 'n43)
       describe "(Prelude.+)" $ do
-        it "doesn't contain type-natural comparison"
-          $ checkInspection $(inspectTest $ 'f59AddPrelude `doesNotUse` 'SLT)
-        it "has the same core as \a b -> (a + b) `mod` 59"
-          $ checkInspection $(inspectTest $ 'f59AddPrelude IT.=== 'f59AddManual)
+        it "has the same core representation as (NA.+) modulo casting" $
+          checkInspection $(inspectTest $ 'f59AddPrelude ==- 'f59AddAlgebra)
       describe "(NA.+)" $ do
+        it "doesn't contain type-classes" $ do
+          checkInspection $(inspectTest $ hasNoTypeClasses 'f59AddAlgebra)
         it "doesn't contain type-natural comparison"
           $ checkInspection $(inspectTest $ 'f59AddAlgebra `doesNotUse` 'SLT)
+        it "doesn't contain Integer type" $
+          checkInspection $(inspectTest $ 'f59AddAlgebra `hasNoType` ''Integer)
+        it "doesn't contain modInteger operation"
+          $ checkInspection $(inspectTest $ 'f59AddAlgebra `doesNotUse` 'modInteger)
         it "has the same core as \a b -> (a + b) `mod` 59"
-          $ checkInspection $(inspectTest $ 'f59AddAlgebra IT.=== 'f59AddManual)
+          $ checkInspection $(inspectTest $ 'f59AddAlgebra ==- 'f59AddManual)
+    describe ("optimisation for big prime (F " ++ show (natVal @LargeP Proxy) ++ ")") $ do
+      describe "literal" $ do
+        it "doesn't contain type-classes"
+          $ checkInspection $(inspectTest $ hasNoTypeClasses 'litLarge)
+        it "is an immediate value modulo casting"
+          $ checkInspection $(inspectTest $ 'litLarge ==- 'litLargeAnswer)
+      describe "(Prelude.+)" $ do
+        it "has the same core representation as (NA.+) modulo casting" $
+          checkInspection $(inspectTest $ 'fLargeAddPrelude ==- 'fLargeAddAlgebra)
+      describe "(NA.+)" $ do
+        it "doesn't contain type-classes" $ do
+          checkInspection $(inspectTest $ hasNoTypeClasses 'fLargeAddAlgebra)
+        it "doesn't contain type-natural comparison"
+          $ checkInspection $(inspectTest $ 'fLargeAddAlgebra `doesNotUse` 'SLT)
+        it "doesn't contain Integer type" $
+          checkInspection $(inspectTest $ 'fLargeAddAlgebra `hasNoType` ''Int)
+        it "doesn't contain modInt# operation"
+          $ checkInspection $(inspectTest $ 'fLargeAddAlgebra `doesNotUse` 'modInt#)
+        it "has the same core as \a b -> (a + b) `mod` p"
+          $ checkInspection $(inspectTest $ 'fLargeAddAlgebra ==- 'fLargeAddManual)
 
 newtype SmallPrime = SmallPrime { runSmallPrime :: Integer }
   deriving newtype (Show)
 
 instance Arbitrary SmallPrime where
   arbitrary = SmallPrime . unPrime
-    <$> QC.elements (take 1000 primes)
+    <$> QC.elements (take 10 primes)
+
+newtype MediumPrime = MediumPrime { runMediumPrime :: Integer }
+  deriving newtype (Show)
+
+instance Arbitrary MediumPrime where
+  arbitrary = MediumPrime . unPrime
+    <$> QC.elements
+        (take 10 [nextPrime
+          $ floor @Double $ sqrt
+          $ fromIntegral $ unPrime bigEnoughPrime
+          .. ])
 
 newtype BigPrime = BigPrime { runBigPrime :: Integer }
   deriving newtype (Show)
 
 instance Arbitrary BigPrime where
   arbitrary = BigPrime . unPrime
-    <$> QC.elements (take 1000 [bigEnoughPrime ..])
+    <$> QC.elements (take 10 [bigEnoughPrime ..])
 
 isField :: IsPrimeChar (p :: Nat) => Proxy (F p) -> F p -> F p -> F p -> Property
 isField _ e f g =

--- a/halg-core-test/test/Spec.hs
+++ b/halg-core-test/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/halg-core/package.yaml
+++ b/halg-core/package.yaml
@@ -50,6 +50,7 @@ dependencies:
 - equational-reasoning
 - ghc-typelits-knownnat
 - ghc-typelits-presburger >= 0.2.0.5
+- singletons-presburger
 - hashable
 - intern
 - lens
@@ -64,4 +65,6 @@ dependencies:
 
 library:
   source-dirs: src
+  dependencies:
+  - template-haskell
   ghc-options: ["-Wall", "-O2"]

--- a/halg-core/src/Algebra/Field/Prime.hs
+++ b/halg-core/src/Algebra/Field/Prime.hs
@@ -121,15 +121,19 @@ liftBinF f = unwrapBinF $ \x y -> wrapF $ fromIntegral $ f x y
 
 instance {-# OVERLAPPING #-}  HasPrimeField Nat where
   type CharInfo n = KnownNat n
+  {-# INLINE charInfo_ #-}
   charInfo_ = fromIntegral . natVal
+  {-# INLINE liftFUnary_ #-}
   liftFUnary_ f = \(F i :: F p) ->
     case sing @WORD_MAX_BOUND %<= sing @p of
       STrue -> F $ f i
       SFalse -> F $ f i
+  {-# INLINE unwrapF #-}
   unwrapF f = \(F i :: F p) ->
     case sing @WORD_MAX_BOUND %<= sing @p of
       STrue -> f i
       SFalse -> f i
+  {-# INLINE wrapF_ #-}
   wrapF_ s =
     (case sing @WORD_MAX_BOUND %<= sing @p of
       STrue -> F s

--- a/halg-core/src/Algebra/Field/Prime.hs
+++ b/halg-core/src/Algebra/Field/Prime.hs
@@ -1,13 +1,19 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DataKinds, FlexibleContexts, FlexibleInstances, GADTs         #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving, LambdaCase, MultiParamTypeClasses #-}
+{-# LANGUAGE MultiWayIf, PolyKinds, QuantifiedConstraints, RankNTypes      #-}
+{-# LANGUAGE ScopedTypeVariables, TemplateHaskell, TypeApplications        #-}
+{-# LANGUAGE TypeFamilies, TypeOperators, UndecidableInstances             #-}
+{-# LANGUAGE UndecidableSuperClasses                                       #-}
+{-# OPTIONS_GHC -fplugin Data.Singletons.TypeNats.Presburger #-}
 -- | Prime fields
-{-# LANGUAGE DataKinds, FlexibleContexts, FlexibleInstances          #-}
-{-# LANGUAGE MultiParamTypeClasses, PolyKinds, RankNTypes            #-}
-{-# LANGUAGE ScopedTypeVariables, TypeFamilies, UndecidableInstances #-}
 module Algebra.Field.Prime
-       ( F(), naturalRepr, reifyPrimeField, withPrimeField
-       , modNat, modNat', modRat, modRat'
-       , FiniteField(..), order
-       ) where
+  ( F(), IsPrimeChar,
+    naturalRepr, reifyPrimeField, withPrimeField,
+    modNat, modNat', modRat, modRat',
+    FiniteField(..), order,
+    -- * Auxiliary interfaces
+    HasPrimeField(..)
+  ) where
 import Algebra.Arithmetic            (modPow)
 import Algebra.Field.Finite
 import Algebra.Normed
@@ -19,12 +25,16 @@ import           Control.Monad.Random         (uniform)
 import           Control.Monad.Random         (runRand)
 import           Control.Monad.Random         (Random (..))
 import qualified Data.Coerce                  as C
+import           Data.Kind                    (Constraint, Type)
 import           Data.Maybe                   (fromMaybe)
 import           Data.Proxy                   (Proxy (..), asProxyTypeOf)
 import qualified Data.Ratio                   as R
 import           Data.Reflection              (Reifies (reflect), reifyNat)
+import           Data.Singletons.Prelude
 import           GHC.Read
 import           GHC.TypeLits                 (KnownNat)
+import           GHC.TypeNats                 (Nat, natVal)
+import           Language.Haskell.TH          (litT, numTyLit)
 import           Numeric.Algebra              (char)
 import           Numeric.Algebra              (Natural)
 import qualified Numeric.Algebra              as NA
@@ -33,44 +43,144 @@ import qualified Prelude                      as P
 
 -- | Prime field of characteristic @p@.
 --   @p@ should be prime, and not statically checked.
-newtype F (p :: k) = F { runF :: Integer }
-                   deriving (NFData)
+newtype F (p :: k) = F { runF :: F' p }
+  -- deriving (NFData)
 
+type WORD_MAX_BOUND =
+  $(litT $ numTyLit $ floor @Double
+    $ sqrt $ fromIntegral $ maxBound @Int)
+type F' (p :: k) = F_Aux k p
+type family F_Aux (k :: Type) (p :: k) where
+  F_Aux Nat p =
+    F_Nat_Aux (WORD_MAX_BOUND <= p)
+  F_Aux k p = Integer
 
-instance Reifies p Integer => Read (F p) where
+type family F_Nat_Aux (oob :: Bool) where
+  F_Nat_Aux 'True  = Integer
+  F_Nat_Aux 'False = Int
+
+instance {-# OVERLAPPING #-} KnownNat p => NFData (F p) where
+  {-# INLINE rnf #-}
+  rnf = case sing @WORD_MAX_BOUND %<= sing @p of
+    STrue -> rnf . runF
+    SFalse -> rnf .runF
+
+instance {-# OVERLAPPABLE #-} NFData (F (p :: Type)) where
+  rnf = rnf . runF
+
+instance IsPrimeChar p => Read (F p) where
   readPrec = fromInteger <$> readPrec
 
-modNat :: Reifies (p :: k) Integer => Integer -> F p
+class HasPrimeField kind where
+  type CharInfo (p :: kind) :: Constraint
+  charInfo_ :: CharInfo (p :: kind) => pxy p -> Integer
+  liftFUnary_
+    :: CharInfo p
+    => (forall x. (Show x, Integral x) => x -> x)
+    -> F (p :: kind) -> F p
+  wrapF_ :: CharInfo p
+    => (forall x. (Show x, Integral x) => x)
+    -> F (p :: kind)
+  unwrapF
+    :: CharInfo p
+    => (forall x. (Show x, Integral x) => x -> a)
+    -> F (p :: kind) -> a
+
+charInfo :: IsPrimeChar p => pxy p -> Integer
+{-# INLINE charInfo #-}
+charInfo = charInfo_
+
+{-# INLINE liftFUnary #-}
+liftFUnary
+  :: forall p. IsPrimeChar p
+  => (forall x. Integral x => x -> x)
+  -> F p -> F p
+liftFUnary f = liftFUnary_ $
+  (`mod` fromInteger (charInfo @p Proxy)) . f
+
+wrapF
+  :: forall p. (IsPrimeChar p)
+  => (forall x. Integral x => x)
+  -> F (p :: kind)
+{-# INLINE wrapF #-}
+wrapF = \s -> wrapF_ (unwrapIntegral $ s `rem` fromInteger (charInfo @p Proxy))
+
+unwrapBinF
+  :: IsPrimeChar p
+  => (forall x. Integral x => x -> x -> a)
+  -> F p -> F p -> a
+{-# INLINE unwrapBinF #-}
+unwrapBinF f = unwrapF $ \i -> unwrapF $ \j -> f i (fromIntegral j)
+
+liftBinF
+  :: IsPrimeChar p
+  => (forall x. Integral x => x -> x -> x)
+  -> F p -> F p -> F p
+{-# INLINE liftBinF #-}
+liftBinF f = unwrapBinF $ \x y -> wrapF $ fromIntegral $ f x y
+
+instance {-# OVERLAPPING #-}  HasPrimeField Nat where
+  type CharInfo n = KnownNat n
+  charInfo_ = fromIntegral . natVal
+  liftFUnary_ f = \(F i :: F p) ->
+    case sing @WORD_MAX_BOUND %<= sing @p of
+      STrue -> F $ f i
+      SFalse -> F $ f i
+  unwrapF f = \(F i :: F p) ->
+    case sing @WORD_MAX_BOUND %<= sing @p of
+      STrue -> f i
+      SFalse -> f i
+  wrapF_ s =
+    (case sing @WORD_MAX_BOUND %<= sing @p of
+      STrue -> F s
+      SFalse -> F s)
+      :: forall p. KnownNat p => F (p :: Nat)
+
+instance HasPrimeField Type where
+  type CharInfo n = Reifies n Integer
+  charInfo_ = reflect
+  liftFUnary_ f = \(F p) -> F $ f p
+  wrapF_ = F
+  unwrapF f = \(F p) -> f p
+
+class (HasPrimeField k, Reifies p Integer, CharInfo p)
+  => IsPrimeChar (p :: k)
+instance (HasPrimeField k, Reifies p Integer, CharInfo p)
+  => IsPrimeChar (p :: k)
+
+modNat :: IsPrimeChar (p :: k) => Integer -> F p
 modNat = modNat' Proxy
 {-# INLINE modNat #-}
 
-modNat' :: forall proxy (p :: k). Reifies p Integer => proxy (F p) -> Integer -> F p
-modNat' _ i =
+modNat' :: forall proxy (p :: k). IsPrimeChar p => proxy (F p) -> Integer -> F p
+modNat' _ i = wrapF $
   let p = reflect (Proxy :: Proxy p)
-  in F (i `rem` p)
+  in unwrapIntegral $ fromInteger i `rem` fromInteger p
 {-# INLINE modNat' #-}
 
-reifyPrimeField :: Integer -> (forall p. KnownNat p => Proxy (F p) -> a) -> a
+reifyPrimeField
+  :: Integer
+  -> (forall p. IsPrimeChar (p :: Nat) => Proxy (F p) -> a) -> a
 reifyPrimeField p f = reifyNat p (f . proxyF)
 
-withPrimeField :: Integer -> (forall p. KnownNat p => F p) -> Integer
-withPrimeField p f = reifyPrimeField p $ runF . asProxyTypeOf f
+withPrimeField :: Integer -> (forall p. IsPrimeChar (p :: Nat) => F p) -> Integer
+withPrimeField p f = reifyPrimeField p $ unwrapF toInteger . asProxyTypeOf f
 
-naturalRepr :: F p -> Integer
-naturalRepr = runF
+naturalRepr :: IsPrimeChar p => F p -> Integer
+naturalRepr = unwrapF toInteger
 
 proxyF :: Proxy (a :: k) -> Proxy (F a)
 proxyF Proxy = Proxy
 
-instance Eq (F p) where
-  F n == F m = n == m
+instance IsPrimeChar p => Eq (F p) where
+  (==) = unwrapBinF (==)
 
-instance Reifies p Integer => Normed (F p) where
+instance IsPrimeChar p => Normed (F p) where
   type Norm (F p) = Integer
-  norm fp@(F p) = p where _ = reflect fp
+  norm = unwrapF toInteger
   liftNorm = modNat
 
-instance Reifies p Integer => P.Num (F p) where
+instance IsPrimeChar p => P.Num (F p) where
   fromInteger = fromInteger'
   {-# INLINE fromInteger #-}
 
@@ -87,99 +197,105 @@ instance Reifies p Integer => P.Num (F p) where
   {-# INLINE (*) #-}
 
   abs = id
-  signum (F 0) = F 0
-  signum (F _) = F 1
+  signum = liftFUnary $ \case
+    0 -> 0
+    _ -> 1
 
-pows :: (P.Integral a1, Reifies p Integer) => F p -> a1 -> F p
-pows a n = modNat $ modPow (runF a) (reflect a) (toInteger n)
+pows :: forall p a1. (P.Integral a1, IsPrimeChar p) => F p -> a1 -> F p
+pows = flip $ \n -> liftFUnary $ \a ->
+  unwrapIntegral $
+  modPow
+    (WrapIntegral a)
+    (WrapIntegral $ fromInteger $ reflect $ Proxy @p) (toInteger n)
 
-instance Reifies p Integer => NA.Additive (F p) where
-  F a + F b = modNat $ a + b
+instance IsPrimeChar p => NA.Additive (F p) where
+  (+) = liftBinF (P.+)
   {-# INLINE (+) #-}
-  sinnum1p n (F k) = modNat $ (1 P.+ P.fromIntegral n) * k
+  sinnum1p n = liftFUnary $ \k -> (1 P.+ P.fromIntegral n) P.* k
   {-# INLINE sinnum1p #-}
 
-instance Reifies p Integer => NA.Multiplicative (F p) where
-  F a * F b = modNat $ a * b
+instance IsPrimeChar p => NA.Multiplicative (F p) where
+  (*) = liftBinF (P.*)
   {-# INLINE (*) #-}
 
   pow1p n p = pows n (p P.+ 1)
   {-# INLINE pow1p #-}
 
-instance Reifies p Integer => NA.Monoidal (F p) where
-  zero = F 0
+instance IsPrimeChar p => NA.Monoidal (F p) where
+  zero = wrapF 0
   {-# INLINE zero #-}
-  sinnum n (F k) = modNat $ P.fromIntegral n * k
+  sinnum n = liftFUnary $ \k -> P.fromIntegral n P.* k
   {-# INLINE sinnum #-}
 
-instance Reifies p Integer => NA.LeftModule Natural (F p) where
-  n .* F p = modNat (n .* p)
+instance IsPrimeChar p => NA.LeftModule Natural (F p) where
+  (.*) n = liftFUnary $ \p -> fromIntegral n P.* p
   {-# INLINE (.*) #-}
 
-instance Reifies p Integer => NA.RightModule Natural (F p) where
-  F p *. n = modNat (p *. n)
+instance IsPrimeChar p => NA.RightModule Natural (F p) where
+  (*.) = flip (.*)
   {-# INLINE (*.) #-}
 
-instance Reifies p Integer => NA.LeftModule Integer (F p) where
-  n .* F p = modNat (n * p)
+instance IsPrimeChar p => NA.LeftModule Integer (F p) where
+  (.*) n = liftFUnary $ \p -> fromIntegral n P.* p
   {-# INLINE (.*) #-}
 
-instance Reifies p Integer => NA.RightModule Integer (F p) where
-  F p *. n = modNat (p * n)
+instance IsPrimeChar p => NA.RightModule Integer (F p) where
+  (*.) = flip (.*)
   {-# INLINE (*.) #-}
 
-instance Reifies p Integer => NA.Group (F p) where
-  F a - F b    = modNat $ a - b
+instance IsPrimeChar p => NA.Group (F p) where
+  (-) = liftBinF (P.-)
   {-# INLINE (-) #-}
 
-  negate (F a) = modNat $ negate a
+  negate = liftFUnary P.negate
   {-# INLINE negate #-}
 
-instance Reifies p Integer => NA.Abelian (F p)
+instance IsPrimeChar p => NA.Abelian (F p)
 
-instance Reifies p Integer => NA.Semiring (F p)
+instance IsPrimeChar p => NA.Semiring (F p)
 
-instance Reifies p Integer => NA.Rig (F p) where
+instance IsPrimeChar p => NA.Rig (F p) where
   fromNatural = modNat . P.fromIntegral
   {-# INLINE fromNatural #-}
 
-instance Reifies p Integer => NA.Ring (F p) where
+instance IsPrimeChar p => NA.Ring (F p) where
   fromInteger = modNat
   {-# INLINE fromInteger #-}
 
-instance Reifies p Integer => NA.DecidableZero (F p) where
-  isZero (F p) = p == 0
+instance IsPrimeChar p => NA.DecidableZero (F p) where
+  isZero = unwrapF (== 0)
 
-instance Reifies p Integer => NA.Unital (F p) where
-  one = F 1
+instance IsPrimeChar p => NA.Unital (F p) where
+  one = wrapF 1
   {-# INLINE one #-}
   pow = pows
   {-# INLINE pow #-}
 
-instance Reifies p Integer => DecidableUnits (F p) where
-  isUnit (F n) = n /= 0
+instance IsPrimeChar p => DecidableUnits (F p) where
+  isUnit = unwrapF (/= 0)
   {-# INLINE isUnit #-}
 
-  recipUnit n@(F k) =
-    let p = fromIntegral $ reflect n
-        (u,_,r) = head $ euclid p k
-    in if u == 1 then Just $ modNat $ fromInteger $ r `rem` p else Nothing
+  recipUnit = unwrapF $ \k ->
+    let p = WrapIntegral $ fromInteger $ charInfo @p Proxy
+        (u,_,r) = head $ euclid p (WrapIntegral k)
+    in if u == 1
+      then Just $ wrapF $ fromIntegral $ unwrapIntegral $ r `rem` p else Nothing
   {-# INLINE recipUnit #-}
 
-instance (Reifies p Integer) => DecidableAssociates (F p) where
+instance (IsPrimeChar p) => DecidableAssociates (F p) where
   isAssociate p n =
     (isZero p && isZero n) || (not (isZero p) && not (isZero n))
   {-# INLINE isAssociate #-}
 
-instance (Reifies p Integer) => UnitNormalForm (F p)
-instance (Reifies p Integer) => IntegralDomain (F p)
-instance (Reifies p Integer) => GCDDomain (F p)
-instance (Reifies p Integer) => UFD (F p)
-instance (Reifies p Integer) => PID (F p)
-instance (Reifies p Integer) => ZeroProductSemiring (F p)
-instance (Reifies p Integer) => Euclidean (F p)
+instance (IsPrimeChar p) => UnitNormalForm (F p)
+instance (IsPrimeChar p) => IntegralDomain (F p)
+instance (IsPrimeChar p) => GCDDomain (F p)
+instance (IsPrimeChar p) => UFD (F p)
+instance (IsPrimeChar p) => PID (F p)
+instance (IsPrimeChar p) => ZeroProductSemiring (F p)
+instance (IsPrimeChar p) => Euclidean (F p)
 
-instance Reifies p Integer => Division (F p) where
+instance IsPrimeChar p => Division (F p) where
   recip = fromMaybe (error "recip: not unit") . recipUnit
   {-# INLINE recip #-}
   a / b =  a * recip b
@@ -187,7 +303,7 @@ instance Reifies p Integer => Division (F p) where
   (^)   = pows
   {-# INLINE (^) #-}
 
-instance Reifies p Integer => P.Fractional (F p) where
+instance IsPrimeChar p => P.Fractional (F p) where
   (/) = C.coerce ((P./) :: WrapAlgebra (F p) -> WrapAlgebra (F p) -> WrapAlgebra (F p))
   {-# INLINE (/) #-}
 
@@ -198,30 +314,30 @@ instance Reifies p Integer => P.Fractional (F p) where
   recip = C.coerce (P.recip :: WrapAlgebra (F p) -> WrapAlgebra (F p))
   {-# INLINE recip #-}
 
-instance Reifies p Integer => NA.Commutative (F p)
+instance IsPrimeChar p => NA.Commutative (F p)
 
-instance Reifies p Integer => NA.Characteristic (F p) where
+instance IsPrimeChar p => NA.Characteristic (F p) where
   char _ = fromIntegral $ reflect (Proxy :: Proxy p)
   {-# INLINE char #-}
 
 
-instance Reifies (p :: k) Integer => Show (F p) where
-  showsPrec d n@(F p) = showsPrec d (p `rem` reflect n)
+instance IsPrimeChar p => Show (F p) where
+  showsPrec d = unwrapF $ showsPrec d
 
-instance Reifies (p :: k) Integer => PrettyCoeff (F p) where
-  showsCoeff d (F p)
-    | p == 0 = Vanished
-    | p == 1 = OneCoeff
-    | otherwise = Positive $ showsPrec d p
+instance IsPrimeChar p => PrettyCoeff (F p) where
+  showsCoeff d = unwrapF $ \p ->
+    if | p == 0 -> Vanished
+       | p == 1 -> OneCoeff
+       | otherwise -> Positive $ showsPrec d p
 
-instance Reifies p P.Integer => FiniteField (F p) where
+instance IsPrimeChar p => FiniteField (F p) where
   power _ = 1
   {-# INLINE power #-}
 
   elements p = map modNat [0.. fromIntegral (char p) - 1]
   {-# INLINE elements #-}
 
-instance Reifies p Integer => Random (F p) where
+instance IsPrimeChar p => Random (F p) where
   random = runRand $ uniform (elements Proxy)
   {-# INLINE random #-}
   randomR (a, b) = runRand $ uniform $ map modNat [naturalRepr a..naturalRepr b]

--- a/halg-core/src/Algebra/Field/Prime.hs
+++ b/halg-core/src/Algebra/Field/Prime.hs
@@ -173,6 +173,8 @@ proxyF :: Proxy (a :: k) -> Proxy (F a)
 proxyF Proxy = Proxy
 
 instance IsPrimeChar p => Eq (F p) where
+  {-# SPECIALISE instance (IsPrimeChar p, (WORD_MAX_BOUND <= p) ~ 'False)
+          => Eq (F p) #-}
   (==) = unwrapBinF (==)
 
 instance IsPrimeChar p => Normed (F p) where
@@ -181,6 +183,8 @@ instance IsPrimeChar p => Normed (F p) where
   liftNorm = modNat
 
 instance IsPrimeChar p => P.Num (F p) where
+  {-# SPECIALISE instance (IsPrimeChar p, (WORD_MAX_BOUND <= p) ~ 'False)
+          => P.Num (F p) #-}
   fromInteger = fromInteger'
   {-# INLINE fromInteger #-}
 
@@ -202,6 +206,7 @@ instance IsPrimeChar p => P.Num (F p) where
     _ -> 1
 
 pows :: forall p a1. (P.Integral a1, IsPrimeChar p) => F p -> a1 -> F p
+{-# INLINE pows #-}
 pows = flip $ \n -> liftFUnary $ \a ->
   unwrapIntegral $
   modPow
@@ -209,12 +214,16 @@ pows = flip $ \n -> liftFUnary $ \a ->
     (WrapIntegral $ fromInteger $ reflect $ Proxy @p) (toInteger n)
 
 instance IsPrimeChar p => NA.Additive (F p) where
+  {-# SPECIALISE instance (IsPrimeChar p, (WORD_MAX_BOUND <= p) ~ 'False)
+          => Additive (F p) #-}
   (+) = liftBinF (P.+)
   {-# INLINE (+) #-}
   sinnum1p n = liftFUnary $ \k -> (1 P.+ P.fromIntegral n) P.* k
   {-# INLINE sinnum1p #-}
 
 instance IsPrimeChar p => NA.Multiplicative (F p) where
+  {-# SPECIALISE instance (IsPrimeChar p, (WORD_MAX_BOUND <= p) ~ 'False)
+          => Multiplicative (F p) #-}
   (*) = liftBinF (P.*)
   {-# INLINE (*) #-}
 
@@ -222,28 +231,40 @@ instance IsPrimeChar p => NA.Multiplicative (F p) where
   {-# INLINE pow1p #-}
 
 instance IsPrimeChar p => NA.Monoidal (F p) where
+  {-# SPECIALISE instance (IsPrimeChar p, (WORD_MAX_BOUND <= p) ~ 'False)
+          => Monoidal (F p) #-}
   zero = wrapF 0
   {-# INLINE zero #-}
   sinnum n = liftFUnary $ \k -> P.fromIntegral n P.* k
   {-# INLINE sinnum #-}
 
 instance IsPrimeChar p => NA.LeftModule Natural (F p) where
+  {-# SPECIALISE instance (IsPrimeChar p, (WORD_MAX_BOUND <= p) ~ 'False)
+          => LeftModule Natural (F p) #-}
   (.*) n = liftFUnary $ \p -> fromIntegral n P.* p
   {-# INLINE (.*) #-}
 
 instance IsPrimeChar p => NA.RightModule Natural (F p) where
+  {-# SPECIALISE instance (IsPrimeChar p, (WORD_MAX_BOUND <= p) ~ 'False)
+          => RightModule Natural (F p) #-}
   (*.) = flip (.*)
   {-# INLINE (*.) #-}
 
 instance IsPrimeChar p => NA.LeftModule Integer (F p) where
+  {-# SPECIALISE instance (IsPrimeChar p, (WORD_MAX_BOUND <= p) ~ 'False)
+          => LeftModule Integer (F p) #-}
   (.*) n = liftFUnary $ \p -> fromIntegral n P.* p
   {-# INLINE (.*) #-}
 
 instance IsPrimeChar p => NA.RightModule Integer (F p) where
+  {-# SPECIALISE instance (IsPrimeChar p, (WORD_MAX_BOUND <= p) ~ 'False)
+          => RightModule Integer (F p) #-}
   (*.) = flip (.*)
   {-# INLINE (*.) #-}
 
 instance IsPrimeChar p => NA.Group (F p) where
+  {-# SPECIALISE instance (IsPrimeChar p, (WORD_MAX_BOUND <= p) ~ 'False)
+          => Group (F p) #-}
   (-) = liftBinF (P.-)
   {-# INLINE (-) #-}
 
@@ -255,23 +276,33 @@ instance IsPrimeChar p => NA.Abelian (F p)
 instance IsPrimeChar p => NA.Semiring (F p)
 
 instance IsPrimeChar p => NA.Rig (F p) where
+  {-# SPECIALISE instance (IsPrimeChar p, (WORD_MAX_BOUND <= p) ~ 'False)
+          => Rig (F p) #-}
   fromNatural = modNat . P.fromIntegral
   {-# INLINE fromNatural #-}
 
 instance IsPrimeChar p => NA.Ring (F p) where
+  {-# SPECIALISE instance (IsPrimeChar p, (WORD_MAX_BOUND <= p) ~ 'False)
+          => Ring (F p) #-}
   fromInteger = modNat
   {-# INLINE fromInteger #-}
 
 instance IsPrimeChar p => NA.DecidableZero (F p) where
+  {-# SPECIALISE instance (IsPrimeChar p, (WORD_MAX_BOUND <= p) ~ 'False)
+          => DecidableZero (F p) #-}
   isZero = unwrapF (== 0)
 
 instance IsPrimeChar p => NA.Unital (F p) where
+  {-# SPECIALISE instance (IsPrimeChar p, (WORD_MAX_BOUND <= p) ~ 'False)
+          => Unital (F p) #-}
   one = wrapF 1
   {-# INLINE one #-}
   pow = pows
   {-# INLINE pow #-}
 
 instance IsPrimeChar p => DecidableUnits (F p) where
+  {-# SPECIALISE instance (IsPrimeChar p, (WORD_MAX_BOUND <= p) ~ 'False)
+          => DecidableUnits (F p) #-}
   isUnit = unwrapF (/= 0)
   {-# INLINE isUnit #-}
 
@@ -283,6 +314,8 @@ instance IsPrimeChar p => DecidableUnits (F p) where
   {-# INLINE recipUnit #-}
 
 instance (IsPrimeChar p) => DecidableAssociates (F p) where
+  {-# SPECIALISE instance (IsPrimeChar p, (WORD_MAX_BOUND <= p) ~ 'False)
+          => DecidableAssociates (F p) #-}
   isAssociate p n =
     (isZero p && isZero n) || (not (isZero p) && not (isZero n))
   {-# INLINE isAssociate #-}
@@ -296,6 +329,8 @@ instance (IsPrimeChar p) => ZeroProductSemiring (F p)
 instance (IsPrimeChar p) => Euclidean (F p)
 
 instance IsPrimeChar p => Division (F p) where
+  {-# SPECIALISE instance (IsPrimeChar p, (WORD_MAX_BOUND <= p) ~ 'False)
+          => Division (F p) #-}
   recip = fromMaybe (error "recip: not unit") . recipUnit
   {-# INLINE recip #-}
   a / b =  a * recip b
@@ -304,6 +339,8 @@ instance IsPrimeChar p => Division (F p) where
   {-# INLINE (^) #-}
 
 instance IsPrimeChar p => P.Fractional (F p) where
+  {-# SPECIALISE instance (IsPrimeChar p, (WORD_MAX_BOUND <= p) ~ 'True)
+          => P.Fractional (F p) #-}
   (/) = C.coerce ((P./) :: WrapAlgebra (F p) -> WrapAlgebra (F p) -> WrapAlgebra (F p))
   {-# INLINE (/) #-}
 

--- a/halg-core/src/Algebra/Field/Prime.hs
+++ b/halg-core/src/Algebra/Field/Prime.hs
@@ -12,7 +12,9 @@ module Algebra.Field.Prime
     modNat, modNat', modRat, modRat',
     FiniteField(..), order,
     -- * Auxiliary interfaces
-    HasPrimeField(..)
+    HasPrimeField(..),
+    -- ** Internals
+    wrapF, liftFUnary, liftBinF
   ) where
 import Algebra.Arithmetic            (modPow)
 import Algebra.Field.Finite

--- a/halg-core/test/Spec.hs
+++ b/halg-core/test/Spec.hs
@@ -1,2 +1,0 @@
-main :: IO ()
-main = putStrLn "Test suite not yet implemented"

--- a/halg-factor/src/Algebra/Ring/Polynomial/Factorise.hs
+++ b/halg-factor/src/Algebra/Ring/Polynomial/Factorise.hs
@@ -26,7 +26,8 @@ import           Control.Lens                       (both, ifoldl, (%~), (&))
 import           Control.Monad                      (guard, replicateM)
 import           Control.Monad                      (when)
 import           Control.Monad.Loops                (iterateUntil, untilJust)
-import           Control.Monad.Random               (MonadRandom, uniform)
+import           Control.Monad.Random               (MonadRandom, getRandomR,
+                                                     uniform)
 import           Control.Monad.ST.Strict            (ST, runST)
 import           Control.Monad.Trans                (lift)
 import           Control.Monad.Trans.Loop           (continue, foreach, while)
@@ -87,7 +88,7 @@ equalDegreeSplitM f d
   | otherwise = do
     let q = fromIntegral $ order (Proxy :: Proxy k)
         els = elements (Proxy :: Proxy k)
-    e <- uniform [1..n P.- 1]
+    e <- getRandomR (1, n P.- 1)
     cs <- replicateM (fromIntegral e) $ uniform els
     let a = var 0 ^ fromIntegral e +
             sum (zipWith (*) (map injectCoeff cs) [var 0 ^ l | l <-[0..]])

--- a/halg-factor/test/Algebra/Ring/Polynomial/FactoriseSpec.hs
+++ b/halg-factor/test/Algebra/Ring/Polynomial/FactoriseSpec.hs
@@ -38,10 +38,10 @@ regressions =
     ξ :: GF 2 5
     ξ = primitive
 
-instance KnownNat n => Arbitrary (F n) where
+instance IsPrimeChar n => Arbitrary (F n) where
   arbitrary = QC.elements $ Fin.elements $ Proxy @(F n)
 
-instance (KnownNat p, KnownNat n, ConwayPolynomial p n)
+instance (IsPrimeChar p, KnownNat n, ConwayPolynomial p n)
       => Arbitrary (GF p n) where
   arbitrary = QC.elements $ Fin.elements $ Proxy @(GF p n)
 

--- a/halg-galois-fields/src/Algebra/Field/Galois.hs
+++ b/halg-galois-fields/src/Algebra/Field/Galois.hs
@@ -3,12 +3,15 @@
 {-# LANGUAGE ParallelListComp, PolyKinds, QuasiQuotes, RankNTypes      #-}
 {-# LANGUAGE ScopedTypeVariables, StandaloneDeriving, TypeApplications #-}
 {-# LANGUAGE TypeFamilies, TypeOperators, UndecidableInstances         #-}
-module Algebra.Field.Galois (GF'(), IsGF', modPoly, modVec,
-                             withIrreducible, linearRepGF, linearRepGF',
-                             reifyGF', generateIrreducible,
-                             withGF', GF, ConwayPolynomial(..),
-                             Conway, primitive, primitive', conway,
-                             conwayFile, addConwayPolynomials)  where
+{-# LANGUAGE UndecidableSuperClasses                                   #-}
+module Algebra.Field.Galois
+  ( GF'(), IsGF', modPoly, modVec,
+    withIrreducible, linearRepGF, linearRepGF',
+    reifyGF', generateIrreducible,
+    withGF', GF, ConwayPolynomial(..),
+    Conway, primitive, primitive', conway,
+    conwayFile, addConwayPolynomials
+  )  where
 import Algebra.Field.Galois.Conway
 import Algebra.Field.Prime
 import Algebra.Internal
@@ -39,7 +42,7 @@ import qualified Prelude                      as P
 -- | Galois field of order @p^n@.
 --   @f@ stands for the irreducible polynomial over @F_p@ of degree @n@.
 newtype GF' p (n :: TL.Nat) (f :: Type) = GF' { runGF' :: Sized n (F p) }
-deriving instance Reifies p Integer => Eq (GF' p n f)
+deriving instance IsPrimeChar p => Eq (GF' p n f)
 
 -- | Galois Field of order @p^n@. This uses conway polynomials
 --   as canonical minimal polynomial and it should be known at
@@ -47,20 +50,20 @@ deriving instance Reifies p Integer => Eq (GF' p n f)
 --   instances should be defined to use field operations).
 type GF (p :: TL.Nat) n = GF' p n (Conway p n)
 
-modPoly :: forall p n f. (KnownNat n, Reifies p Integer) => Unipol (F p) -> GF' p n f
+modPoly :: forall p n f. (KnownNat n, IsPrimeChar p) => Unipol (F p) -> GF' p n f
 modPoly = GF' . polyToVec
 
 modVec :: Sized n (F p) -> GF' p n f
 modVec = GF'
 
-instance (Reifies p Integer, Show (F p)) => Show (GF' p n f)  where
+instance (IsPrimeChar p, Show (F p)) => Show (GF' p n f)  where
   showsPrec d (GF' (v :< vs)) =
     if F.all isZero vs
     then showsPrec d v
     else showChar '<' . showString (showPolynomialWith (singleton "ξ") 0 $ vecToPoly $ v :< vs) . showChar '>'
   showsPrec _ _ = showString "0"
 
-instance (Reifies p Integer, Show (F p)) => PrettyCoeff (GF' p n f)
+instance (IsPrimeChar p, Show (F p)) => PrettyCoeff (GF' p n f)
 
 varX :: CoeffRing r => Unipol r
 varX = var [od|0|]
@@ -79,97 +82,97 @@ polyToVec f =
         | i <- [0..fromIntegral (fromSing (sing :: SNat n)) P.- 1]
         ]
 
-instance Reifies p Integer => Additive (GF' p n f)  where
+instance IsPrimeChar p => Additive (GF' p n f)  where
   GF' v + GF' u = GF' $ SV.zipWithSame (+) v u
 
-instance (Reifies p Integer, KnownNat n) => Monoidal (GF' p n f) where
+instance (IsPrimeChar p, KnownNat n) => Monoidal (GF' p n f) where
   zero = GF' $ SV.replicate' zero
 
-instance Reifies p Integer => LeftModule Natural (GF' p n f) where
+instance IsPrimeChar p => LeftModule Natural (GF' p n f) where
   n .* GF' v = GF' $ SV.map (n .*) v
 
-instance Reifies p Integer => RightModule Natural (GF' p n f) where
+instance IsPrimeChar p => RightModule Natural (GF' p n f) where
   GF' v *. n = GF' $ SV.map (*. n) v
 
-instance Reifies p Integer => LeftModule Integer (GF' p n f) where
+instance IsPrimeChar p => LeftModule Integer (GF' p n f) where
   n .* GF' v = GF' $ SV.map (n .*) v
 
-instance Reifies p Integer => RightModule Integer (GF' p n f) where
+instance IsPrimeChar p => RightModule Integer (GF' p n f) where
   GF' v *. n = GF' $ SV.map (*. n) v
 
-instance (KnownNat n, Reifies p Integer) => Group (GF' p n f) where
+instance (KnownNat n, IsPrimeChar p) => Group (GF' p n f) where
   negate (GF' v) = GF' $ SV.map negate v
   GF' u - GF' v  = GF' $ SV.zipWithSame (-) u v
 
-instance (Reifies p Integer) => Abelian (GF' p n f)
+instance (IsPrimeChar p) => Abelian (GF' p n f)
 
-instance (KnownNat n, Reifies f (Unipol (F p)), Reifies p Integer)
+instance (KnownNat n, Reifies f (Unipol (F p)), IsPrimeChar p)
       => Multiplicative (GF' p n f) where
   GF' u * GF' v =
     let t = (vecToPoly u * vecToPoly v) `rem` reflect (Proxy :: Proxy f)
     in GF' $ polyToVec t
 
-instance (KnownNat n, Reifies f (Unipol (F p)), Reifies p Integer) => Unital (GF' p n f) where
+instance (KnownNat n, Reifies f (Unipol (F p)), IsPrimeChar p) => Unital (GF' p n f) where
   one =
     case zeroOrSucc (sing :: SNat n) of
       IsZero   -> GF' NilL
       IsSucc k -> withKnownNat k $ GF' $ one :< SV.replicate' zero
 
-instance (KnownNat n, Reifies f (Unipol (F p)), Reifies p Integer) => Semiring (GF' p n f)
+instance (KnownNat n, Reifies f (Unipol (F p)), IsPrimeChar p) => Semiring (GF' p n f)
 
-instance (KnownNat n, Reifies f (Unipol (F p)), Reifies p Integer) => Rig (GF' p n f) where
+instance (KnownNat n, Reifies f (Unipol (F p)), IsPrimeChar p) => Rig (GF' p n f) where
   fromNatural n =
     case zeroOrSucc (sing :: SNat n) of
       IsZero -> GF' SV.empty
       IsSucc k -> withKnownNat k $ GF' $ fromNatural n :< SV.replicate' zero
 
-instance (KnownNat n, Reifies f (Unipol (F p)), Reifies p Integer) => Commutative (GF' p n f)
+instance (KnownNat n, Reifies f (Unipol (F p)), IsPrimeChar p) => Commutative (GF' p n f)
 
-instance (KnownNat n, Reifies f (Unipol (F p)), Reifies p Integer) => Ring (GF' p n f) where
+instance (KnownNat n, Reifies f (Unipol (F p)), IsPrimeChar p) => Ring (GF' p n f) where
   fromInteger n =
     case zeroOrSucc (sing :: SNat n) of
       IsZero   -> GF' NilL
       IsSucc k -> withKnownNat k $ GF' $ fromInteger n :< SV.replicate' zero
 
-instance (KnownNat n, Reifies p Integer) => DecidableZero (GF' p n f) where
+instance (KnownNat n, IsPrimeChar p) => DecidableZero (GF' p n f) where
   isZero (GF' sv) = F.all isZero sv
 
-instance (KnownNat n, Reifies p Integer, Reifies f (Unipol (F p))) => DecidableUnits (GF' p n f) where
+instance (KnownNat n, IsPrimeChar p, Reifies f (Unipol (F p))) => DecidableUnits (GF' p n f) where
   isUnit (GF' sv) = not $ F.all isZero sv
   recipUnit a | isZero a = Nothing
               | otherwise = Just $ recip a
 
-instance (Reifies p Integer, Reifies f (Unipol (F p)), KnownNat n)
+instance (IsPrimeChar p, Reifies f (Unipol (F p)), KnownNat n)
       => Characteristic (GF' p n f) where
   char _ = char (Proxy :: Proxy (F p))
 
-instance (Reifies p Integer, Reifies f (Unipol (F p)), KnownNat n)
+instance (IsPrimeChar p, Reifies f (Unipol (F p)), KnownNat n)
       => Division (GF' p n f) where
   recip f =
     let p = reflect (Proxy :: Proxy f)
         (_,_,r) = P.head $ euclid p $ vecToPoly $ runGF' f
     in GF' $ polyToVec $ r `rem` p
 
-instance (KnownNat n, Reifies p Integer, Reifies f (Unipol (F p)))
+instance (KnownNat n, IsPrimeChar p, Reifies f (Unipol (F p)))
       => DecidableAssociates (GF' p n f) where
   isAssociate p n =
     (isZero p && isZero n) || (not (isZero p) && not (isZero n))
-instance (KnownNat n, Reifies p Integer, Reifies f (Unipol (F p)))
+instance (KnownNat n, IsPrimeChar p, Reifies f (Unipol (F p)))
       => ZeroProductSemiring (GF' p n f)
-instance (KnownNat n, Reifies p Integer, Reifies f (Unipol (F p)))
+instance (KnownNat n, IsPrimeChar p, Reifies f (Unipol (F p)))
       => UnitNormalForm (GF' p n f)
-instance (KnownNat n, Reifies p Integer, Reifies f (Unipol (F p)))
+instance (KnownNat n, IsPrimeChar p, Reifies f (Unipol (F p)))
       => IntegralDomain (GF' p n f)
-instance (KnownNat n, Reifies p Integer, Reifies f (Unipol (F p)))
+instance (KnownNat n, IsPrimeChar p, Reifies f (Unipol (F p)))
       => GCDDomain (GF' p n f)
-instance (KnownNat n, Reifies p Integer, Reifies f (Unipol (F p)))
+instance (KnownNat n, IsPrimeChar p, Reifies f (Unipol (F p)))
       => UFD (GF' p n f)
-instance (KnownNat n, Reifies p Integer, Reifies f (Unipol (F p)))
+instance (KnownNat n, IsPrimeChar p, Reifies f (Unipol (F p)))
       => PID (GF' p n f)
-instance (KnownNat n, Reifies p Integer, Reifies f (Unipol (F p)))
+instance (KnownNat n, IsPrimeChar p, Reifies f (Unipol (F p)))
       => Euclidean (GF' p n f)
 
-instance (Reifies p Integer, Reifies f (Unipol (F p)), KnownNat n) => P.Num (GF' p n f) where
+instance (IsPrimeChar p, Reifies f (Unipol (F p)), KnownNat n) => P.Num (GF' p n f) where
   (+) = (NA.+)
   (-) = (NA.-)
   negate = NA.negate
@@ -178,7 +181,7 @@ instance (Reifies p Integer, Reifies f (Unipol (F p)), KnownNat n) => P.Num (GF'
   abs = error "not defined"
   signum = error "not defined"
 
-instance (Reifies p Integer, Reifies f (Unipol (F p)), KnownNat n) => P.Fractional (GF' p n f) where
+instance (IsPrimeChar p, Reifies f (Unipol (F p)), KnownNat n) => P.Fractional (GF' p n f) where
   fromRational u = fromInteger (Rat.numerator u) / fromInteger (Rat.denominator u)
   (/) = (/)
   recip = recip
@@ -202,24 +205,25 @@ withIrreducible r f =
       withKnownNat sn $
       reify r (f. proxyGF' (Proxy :: Proxy (F n)) sn)
 
-reifyGF' :: MonadRandom m => Natural -> Natural
-         -> (forall (p :: TL.Nat) (f :: Type) (n :: TL.Nat) . (Reifies p Integer, Reifies f (Unipol (F p)))
-                       => Proxy (GF' p n f) -> a)
-         -> m a
+reifyGF'
+  :: MonadRandom m => Natural -> Natural
+  -> (forall (p :: TL.Nat) (f :: Type) (n :: TL.Nat) . (IsPrimeChar p, Reifies f (Unipol (F p)))
+                => Proxy (GF' p n f) -> a)
+  -> m a
 reifyGF' p n f = reifyPrimeField (P.toInteger p) $ \pxy -> do
   mpol <- generateIrreducible pxy n
   case toSing (fromIntegral p) of
     SomeSing sp -> return $ withKnownNat sp $ withIrreducible mpol f
 
-linearRepGF :: GF' p n f -> V.Vector (F p)
+linearRepGF :: IsPrimeChar p => GF' p n f -> V.Vector (F p)
 linearRepGF = SV.unsized . runGF'
 
-linearRepGF' :: GF' p n f -> V.Vector Integer
+linearRepGF' :: IsPrimeChar p => GF' p n f -> V.Vector Integer
 linearRepGF' = V.map naturalRepr . linearRepGF
 
 withGF' :: MonadRandom m
         => Natural -> Natural
-        -> (forall (p :: TL.Nat) f (n :: TL.Nat) . (Reifies p Integer, Reifies f (Unipol (F p)))
+        -> (forall (p :: TL.Nat) f (n :: TL.Nat) . (IsPrimeChar p, Reifies f (Unipol (F p)))
             => GF' p n f)
         -> m (V.Vector Integer)
 withGF' p n f = reifyGF' p n $ V.map naturalRepr . linearRepGF . asProxyTypeOf f
@@ -228,11 +232,9 @@ proxyGF' :: Proxy (F p) -> SNat n -> Proxy f -> Proxy (GF' p n f)
 proxyGF' _ _ Proxy = Proxy
 
 -- | Type-constraint synonym to work with Galois field.
-class (KnownNat n, KnownNat p, Reifies f (Unipol (F p))) => IsGF' p n f
-instance (KnownNat n, KnownNat p, Reifies f (Unipol (F p))) => IsGF' p n f
+class (KnownNat n, IsPrimeChar p, Reifies f (Unipol (F p))) => IsGF' p n f
+instance (KnownNat n, IsPrimeChar p, Reifies f (Unipol (F p))) => IsGF' p n f
 
-
-instance (KnownNat n, IsGF' p n f) => ZeroProductSemiring (GF' p n f)
 
 instance (KnownNat n, IsGF' p n f) => FiniteField (GF' p n f) where
   power _ = fromIntegral $ fromSing (sing :: SNat n)

--- a/halg-galois-fields/src/Algebra/Field/Galois.hs
+++ b/halg-galois-fields/src/Algebra/Field/Galois.hs
@@ -195,7 +195,7 @@ generateIrreducible p n =
     let f = varX^n + sum [ injectCoeff c * (varX^i) | c <- cs | i <- [0..n P.- 1]]
     return f
 
-withIrreducible :: forall p a. KnownNat p
+withIrreducible :: forall p a. IsPrimeChar p
                 => Unipol (F p)
                 -> (forall f (n :: Nat). (Reifies f (Unipol (F p))) => Proxy (GF' p n f) -> a)
                 -> a

--- a/hie.yaml
+++ b/hie.yaml
@@ -41,6 +41,8 @@ cradle:
 
     - path: "halg-core/src"
       component: "halg-core:lib"
+    - path: "halg-core-test/test"
+      component: "halg-core-test:test:halg-core-specs"
 
     - path: "halg-heaps/src"
       component: "halg-heaps:lib"


### PR DESCRIPTION
Currently, a prime field `F p` is represented by `Integer`; but we can use `Int` instead for *small enough* prime `p`s.
This branch implements a type-level hack to allow such a conditional representation choice.