### PR TITLE
GHC 9.0 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ cabal-dev
 .hsenv
 .cabal-sandbox/
 cabal.sandbox.config
+cabal.project.local
+dist-newstyle/
 *.prof
 *.aux
 *.hp

--- a/algebraic-prelude/algebraic-prelude.cabal
+++ b/algebraic-prelude/algebraic-prelude.cabal
@@ -37,7 +37,7 @@ library
   build-depends:
       base >=4.7 && <5
     , basic-prelude
-    , lens ==4.*
+    , lens >= 4.0 && < 5.1
     , semigroups
   if impl(ghc >=8.4)
     build-depends:

--- a/algebraic-prelude/src/AlgebraicPrelude.hs
+++ b/algebraic-prelude/src/AlgebraicPrelude.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ConstraintKinds, FlexibleContexts, FlexibleInstances      #-}
+{-# LANGUAGE CPP, ConstraintKinds, FlexibleContexts, FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving, MultiParamTypeClasses         #-}
 {-# LANGUAGE NoImplicitPrelude, NoRebindableSyntax, StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell, TypeFamilies, UndecidableInstances       #-}
@@ -76,6 +76,9 @@ import           BasicPrelude                          as AlgebraicPrelude hidin
                                                                             read,
                                                                             readFile,
                                                                             show,
+#if MIN_VERSION_base(4,14,0)
+                                                                            singleton,
+#endif
                                                                             subtract,
                                                                             sum,
                                                                             unlines,

--- a/halg-algorithms/cabal.project
+++ b/halg-algorithms/cabal.project
@@ -1,0 +1,9 @@
+packages: .,
+  ../algebraic-prelude,
+  ../halg-core,
+  ../halg-heaps,
+  ../halg-matrices,
+  ../halg-polynomials
+
+allow-newer:
+  equational-reasoning:template-haskell

--- a/halg-algorithms/halg-algorithms.cabal
+++ b/halg-algorithms/halg-algorithms.cabal
@@ -57,6 +57,7 @@ library
     , equational-reasoning
     , foldl
     , ghc-typelits-knownnat
+    , ghc-typelits-natnormalise
     , ghc-typelits-presburger
     , halg-core
     , halg-heaps
@@ -72,11 +73,17 @@ library
     , parallel
     , reflection
     , semigroups
-    , singletons
     , singletons-presburger
     , sized
     , type-natural
     , vector
+  if impl(ghc >= 9.0)
+    build-depends:
+        singletons >= 3.0
+      , singletons-base
+  else
+    build-depends:
+        singletons < 3.0
   default-language: Haskell2010
 
 executable f4-prof

--- a/halg-algorithms/src/Algebra/Ring/Polynomial/Homogenised.hs
+++ b/halg-algorithms/src/Algebra/Ring/Polynomial/Homogenised.hs
@@ -7,6 +7,7 @@
 {-# OPTIONS_GHC -fplugin Data.Singletons.TypeNats.Presburger #-}
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.Presburger #-}
+{-# OPTIONS_GHC -fplugin GHC.TypeLits.Normalise #-}
 
 module Algebra.Ring.Polynomial.Homogenised (Homogenised, homogenise, unhomogenise, tryHomogenise, HomogOrder) where
 

--- a/halg-core/cabal.project
+++ b/halg-core/cabal.project
@@ -1,0 +1,5 @@
+packages: .,
+  ../algebraic-prelude
+
+allow-newer:
+  equational-reasoning:template-haskell

--- a/halg-core/halg-core.cabal
+++ b/halg-core/halg-core.cabal
@@ -54,13 +54,19 @@ library
     , lens
     , mono-traversable
     , reflection
-    , singletons
     , singletons-presburger >=0.4
     , sized
     , type-natural
     , unordered-containers
     , vector
     , vector-instances
+  if impl(ghc >= 9.0)
+    build-depends:
+        singletons >= 3.0
+      , singletons-base
+  else
+    build-depends:
+        singletons < 3.0
   exposed-modules:
       Algebra.Arithmetic
       Algebra.Field.Finite

--- a/halg-core/src/Algebra/Internal.hs
+++ b/halg-core/src/Algebra/Internal.hs
@@ -36,6 +36,17 @@ import qualified Data.Foldable as F
 import Data.Kind (Type)
 import Data.Proxy (KProxy (..), Proxy (..), asProxyTypeOf)
 import qualified Data.Sequence as Seq
+
+#if MIN_VERSION_singletons(3,0,0)
+import Data.Singletons as Algebra.Internal
+  ( Sing,
+    SingI (..),
+    SingKind (..),
+    SomeSing (..),
+    withSingI,
+  )
+import qualified GHC.TypeLits.Singletons as Sing
+#else
 import Data.Singletons.Prelude as Algebra.Internal
   ( Sing,
     SingI (..),
@@ -44,6 +55,8 @@ import Data.Singletons.Prelude as Algebra.Internal
     withSingI,
   )
 import qualified Data.Singletons.TypeLits as Sing
+#endif
+
 import Data.Sized as Algebra.Internal
   ( generate,
     sIndex,

--- a/halg-core/src/Algebra/Ring/Polynomial/Monomial.hs
+++ b/halg-core/src/Algebra/Ring/Polynomial/Monomial.hs
@@ -103,8 +103,13 @@ import Data.MonoTraversable
   )
 import Data.Monoid (Dual (..), Sum (..))
 import qualified Data.Semigroup as Semi
+
+#if MIN_VERSION_singletons(3,0,0)
+import Data.List.Singletons (SList, Length, Replicate, sReplicate)
+#else
 import Data.Singletons.Prelude (SList)
 import Data.Singletons.Prelude.List (Length, Replicate, sReplicate)
+#endif
 import qualified Data.Sized as V
 import Data.Type.Natural.Lemma.Order
 import qualified Data.Vector.Generic as G

--- a/halg-matrices/cabal.project
+++ b/halg-matrices/cabal.project
@@ -1,0 +1,7 @@
+packages: .,
+  ../algebraic-prelude,
+  ../halg-core,
+  ../halg-polynomials
+
+allow-newer:
+  equational-reasoning:template-haskell

--- a/halg-matrices/src/Algebra/Matrix/RepaIntMap.hs
+++ b/halg-matrices/src/Algebra/Matrix/RepaIntMap.hs
@@ -1,8 +1,12 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveFunctor, PartialTypeSignatures, PatternSynonyms #-}
 {-# LANGUAGE StandaloneDeriving, TypeOperators, ViewPatterns       #-}
 {-# OPTIONS_GHC -rtsopts -threaded -fno-liberate-case     #-}
 {-# OPTIONS_GHC  -fmax-simplifier-iterations=20 #-}
-{-# OPTIONS_GHC -funfolding-keeness-factor1000 -fllvm -optlo-O3 #-}
+{-# OPTIONS_GHC -funfolding-keeness-factor1000 -optlo-O3 #-}
+#ifndef mingw32_HOST_OS
+{-# OPTIONS_GHC -fllvm #-}
+#endif
 {-# OPTIONS_GHC -fsimplifier-phases=3  #-}
 {-# OPTIONS_GHC -funfolding-use-threshold1000                   #-}
 module Algebra.Matrix.RepaIntMap

--- a/halg-polynomials/cabal.project
+++ b/halg-polynomials/cabal.project
@@ -1,0 +1,6 @@
+packages: .,
+  ../algebraic-prelude,
+  ../halg-core
+
+allow-newer:
+  equational-reasoning:template-haskell

--- a/halg-polynomials/halg-polynomials.cabal
+++ b/halg-polynomials/halg-polynomials.cabal
@@ -51,7 +51,6 @@ library
     , monad-loops
     , mono-traversable
     , reflection
-    , singletons
     , singletons-presburger
     , sized
     , text
@@ -59,6 +58,13 @@ library
     , unamb
     , unordered-containers
     , vector
+  if impl(ghc >= 9.0)
+    build-depends:
+        singletons >= 3.0
+      , singletons-base
+  else
+    build-depends:
+        singletons < 3.0
   exposed-modules:
       Algebra.Algorithms.Groebner
       Algebra.Algorithms.Groebner.SelectionStrategy

--- a/halg-polynomials/src/Algebra/Ring/Polynomial/Internal.hs
+++ b/halg-polynomials/src/Algebra/Ring/Polynomial/Internal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ExplicitNamespaces #-}
@@ -69,7 +70,11 @@ import qualified Data.Map.Merge.Strict as MM
 import qualified Data.Map.Strict as M
 import Data.MonoTraversable (osum)
 import qualified Data.Set as Set
+#if MIN_VERSION_singletons(3,0,0)
+import Data.List.Singletons (Replicate)
+#else
 import Data.Singletons.Prelude.List (Replicate)
+#endif
 import qualified Data.Sized as S
 import Data.Type.Natural.Lemma.Order
 import qualified Numeric.Algebra as NA

--- a/halg-polynomials/src/Algebra/Ring/Polynomial/Labeled.hs
+++ b/halg-polynomials/src/Algebra/Ring/Polynomial/Labeled.hs
@@ -44,14 +44,22 @@ import Control.DeepSeq (NFData)
 import Control.Lens (each, (%~), (&))
 import qualified Data.Coerce as DC
 import qualified Data.List as L
+#if MIN_VERSION_singletons(3,0,0)
+import Data.Singletons (type (@@))
+import Data.Eq.Singletons
+import Data.Function.Singletons (FlipSym0)
+import Data.List.Singletons hiding (Group)
+import Data.Maybe.Singletons
+#else
 import Data.Singletons.Prelude hiding (SNum(..))
 import Data.Singletons.Prelude.List hiding (Group)
+#endif
 import qualified Data.Sized as S
 import GHC.Exts (Constraint)
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 802
 import qualified Data.Text as T
 #endif
-import GHC.TypeLits (symbolVal, TypeError, ErrorMessage(..), KnownSymbol)
+import GHC.TypeLits (symbolVal, TypeError, ErrorMessage(..), Symbol, KnownSymbol)
 import qualified Numeric.Algebra as NA
 import qualified Prelude as P
 


### PR DESCRIPTION
This adds GHC 9.0 and singletons 3.0 support for:

- `algebraic-prelude`
- `halg-algorithms`
- `halg-core`
- `halg-matrices`
- `halg-polynomials`

I'm using cabal and not stack, which is why I added some `cabal.project` files. I hope that's OK.