### PR TITLE
Fixes GH Pages generation path

### DIFF
--- a/.github/dhall/pages.dhall
+++ b/.github/dhall/pages.dhall
@@ -76,7 +76,9 @@ in  { name = "Update Documentation"
                   )
               }
             , lib.action/run
-                { name = "Extract artifacts", run = "unzip ${docs-zip}" }
+                { name = "Extract artifacts"
+                , run = "unzip ${docs-zip} -d ./docs"
+                }
             , lib.action/run
                 { name = "Generate static site"
                 , run = "stack exec -- site build"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,7 +48,7 @@ jobs:
           let fs = require('fs');
           fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/docs.zip`, Buffer.from(download.data));
     - name: Extract artifacts
-      run: unzip docs.zip
+      run: "unzip docs.zip -d ./docs"
     - name: Generate static site
       run: "stack exec -- site build"
     - name: Deploy GitHub Pages

--- a/stack-8.10.7.yaml.lock
+++ b/stack-8.10.7.yaml.lock
@@ -18,6 +18,13 @@ packages:
       sha256: e0bb7221ac929e5fe3722f4838551e962589a8fed18199d9791385864855f466
   original:
     hackage: control-monad-loop-0.1
+- completed:
+    hackage: unamb-0.2.7@sha256:ce5db0575bca8ca04c9e9dce3ba75b6f9e5ceea834c6ba4fae45aca6fa963334,2385
+    pantry-tree:
+      size: 217
+      sha256: c3c4ac7408c2999b6779714459d2433ff2495f90161d7c3ca349ca3aa6386be8
+  original:
+    hackage: unamb-0.2.7
 snapshots:
 - completed:
     size: 586110


### PR DESCRIPTION
Current GH Pages script fails to extract documents.
This PR fixes the situation to pass `-d` option to `unzip`.